### PR TITLE
Remove unnecessary async keywords to reduce bundle size

### DIFF
--- a/packages/js-web-sdk/src/DatafileLoaders.ts
+++ b/packages/js-web-sdk/src/DatafileLoaders.ts
@@ -73,7 +73,7 @@ export class FetchUrlDatafileLoader implements ResourceLoader<OptimizelyDatafile
 
   private static READY_STATE_COMPLETE = 4
 
-  async fetchDatafile(): Promise<OptimizelyDatafile> {
+  fetchDatafile(): Promise<OptimizelyDatafile> {
     const datafileUrl = `https://cdn.optimizely.com/datafiles/${this.sdkKey}.json`
     return new Promise((resolve, reject) => {
       const req = new XMLHttpRequest()

--- a/packages/js-web-sdk/src/OptimizelySDKWrapper.ts
+++ b/packages/js-web-sdk/src/OptimizelySDKWrapper.ts
@@ -99,7 +99,7 @@ export class OptimizelySDKWrapper implements OptimizelyClientWrapper {
    * @returns {Promise<boolean>}
    * @memberof OptimizelySDKWrapper
    */
-  public async onReady(config: { timeout?: number } = {}): Promise<boolean> {
+  public onReady(config: { timeout?: number } = {}): Promise<boolean> {
     let timeoutId: number | undefined
 
     if (config.timeout == null) {


### PR DESCRIPTION
These functions don't need to be async. This reduces the size of the built scripts a little bit.