### PR TITLE
feat(datafileUrl): Add ability to initialize with fully qualified url

### DIFF
--- a/packages/js-web-sdk/src/DatafileLoaders.ts
+++ b/packages/js-web-sdk/src/DatafileLoaders.ts
@@ -37,16 +37,23 @@ type FetchUrlCacheEntry = {
 }
 
 export class FetchUrlDatafileLoader implements ResourceLoader<OptimizelyDatafile> {
-  private sdkKey: string
+  private datafileUrl: string | undefined
+  private sdkKey: string | undefined
   private localStorageKey: string
 
   // 1 week in ms = 7 days * 24 hours * 60 minutes * 60 seconds * 1000 ms
   private static MAX_CACHE_AGE_MS: number = 7 * 24 * 60 * 60 * 1000
 
   constructor(config: {
-    sdkKey: string
+    datafileUrl?: string
+    sdkKey?: string
     localStorageKey?: string
   }) {
+    if (!config.datafileUrl && !config.sdkKey) {
+      throw new Error('Must supply either "datafileUrl", "sdkKey"')
+    }
+
+    this.datafileUrl = config.datafileUrl
     this.sdkKey = config.sdkKey
     this.localStorageKey = config.localStorageKey || 'optly_fs_datafile'
   }
@@ -89,7 +96,7 @@ export class FetchUrlDatafileLoader implements ResourceLoader<OptimizelyDatafile
   private static READY_STATE_COMPLETE = 4
 
   fetchDatafile(): Promise<OptimizelyDatafile> {
-    const datafileUrl = `https://cdn.optimizely.com/datafiles/${this.sdkKey}.json`
+    const datafileUrl = this.datafileUrl || `https://cdn.optimizely.com/datafiles/${this.sdkKey}.json`
     return new Promise((resolve, reject) => {
       const req = new XMLHttpRequest()
       req.open(FetchUrlDatafileLoader.GET_METHOD, datafileUrl, true);

--- a/packages/js-web-sdk/src/OptimizelySDKWrapper.ts
+++ b/packages/js-web-sdk/src/OptimizelySDKWrapper.ts
@@ -39,6 +39,7 @@ type UserAttributes = {
 
 export interface OptimizelySDKWrapperConfig extends Partial<optimizely.Config> {
   datafile?: OptimizelyDatafile
+  datafileUrl?: string
   sdkKey?: string
 }
 
@@ -434,12 +435,16 @@ export class OptimizelySDKWrapper implements OptimizelyClientWrapper {
       datafileLoader = new ProvidedDatafileLoader({
         datafile: config.datafile,
       })
+    } else if (config.datafileUrl) {
+      datafileLoader = new FetchUrlDatafileLoader({
+        datafileUrl: config.datafileUrl,
+      })
     } else if (config.sdkKey) {
       datafileLoader = new FetchUrlDatafileLoader({
         sdkKey: config.sdkKey,
       })
     } else {
-      throw new Error('Must supply either "datafile", "sdkKey"')
+      throw new Error('Must supply either "datafile", "datafileUrl", "sdkKey"')
     }
 
     return new Resource(datafileLoader)

--- a/packages/js-web-sdk/test/testPublishedSdkWrapper.ts
+++ b/packages/js-web-sdk/test/testPublishedSdkWrapper.ts
@@ -96,5 +96,31 @@ export default function testPublishedSDKWrapper(wrapperIndex: SDKWrapperIndex): 
         assert.isTrue(instance.isInitialized)
       })
     })
+
+    describe('when constructed with datafileUrl', function() {
+      let datafileStubs: DatafileRequestStubs
+
+      this.beforeEach(() => {
+        datafileStubs = setupDatafileRequestStubs()
+        datafileStubs.setup()
+        instance = wrapperIndex.createInstance({
+          datafileUrl: 'http://www.test.com/datafile.json',
+          eventDispatcher: { dispatchEvent },
+          logger: { log },
+        })
+      })
+
+      this.afterEach(() => {
+        datafileStubs.restore()
+      })
+
+      it('should support onReady', async () => {
+        assert.isFalse(instance.isInitialized)
+        assert.equal(datafileStubs.requests[0].url, 'http://www.test.com/datafile.json')
+        datafileStubs.requests[0].respond(200, {}, JSON.stringify(datafile));
+        await instance.onReady()
+        assert.isTrue(instance.isInitialized)
+      })
+    })
   }
 }


### PR DESCRIPTION
**Summary:**
This PR enables developers to pass in a parameter `datafileUrl` to the `createInstance` API of the SDK. Example:

```
const optimizely = optimizelySDK.createInstance({
  datafileUrl: 'http://cdn.my-app.com/datafile/GaXr9RoDhRcqXJm3ruskRa.json',
})
```

This is useful for the onboarding tutorial where the datafile url is a special url which is not the same as the production datafiles. We think this feature will be useful for other consumers of the SDK who might want full control over the hosting of their datafiles too.

cc: @zleach 