### PR TITLE
doc(rollouts): Add comment on using attributes

### DIFF
--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -209,6 +209,24 @@ import { OptimizelyExperiment, OptimizelyVariation } from '@optimizely/react-sdk
 </OptimizelyFeature>
 ```
 
+### Rollout a feature user-by-user
+
+To rollout a feature by user rather than by random percentage, setup an attribute in Optimizely and create an Audience, which uses that attribute. Then pass along this attribute to the Provider.
+```
+  <OptimizelyProvider
+    optimizely={optimizely}
+    timeout={500}
+    userId={'user123'}     // UserId used for random percentage rollout 
+    userAttributes={{ 
+      user_id: 'user123'   // Attribute used for non-random audience rollout
+      plan_type: 'bronze',
+    }}
+  >
+```
+
+See the documentation to [run a beta](https://docs.developers.optimizely.com/rollouts/docs/run-a-beta).
+
+
 ### Programmatic access inside component
 
 Any component under the `<OptimizelyProvider>` can access the Optimizely `js-web-sdk` via the higher-order component (HoC) `withOptimizely`.

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -209,9 +209,9 @@ import { OptimizelyExperiment, OptimizelyVariation } from '@optimizely/react-sdk
 </OptimizelyFeature>
 ```
 
-### Rollout a feature user-by-user
+### Rollout or experiment a feature user-by-user
 
-To rollout a feature by user rather than by random percentage, setup an attribute in Optimizely and create an Audience, which uses that attribute. Then pass along this attribute to the Provider.
+To rollout or experiment on a feature by user rather than by random percentage, setup an attribute in Optimizely and create an Audience, which uses that attribute. Then pass along this attribute to the Provider.
 ```
   <OptimizelyProvider
     optimizely={optimizely}
@@ -224,7 +224,7 @@ To rollout a feature by user rather than by random percentage, setup an attribut
   >
 ```
 
-See the documentation to [run a beta](https://docs.developers.optimizely.com/rollouts/docs/run-a-beta).
+This kind of targeted rollout or experiment is used when running a beta. For more information see the documentation on how to [run a beta](https://docs.developers.optimizely.com/rollouts/docs/run-a-beta).
 
 
 ### Programmatic access inside component


### PR DESCRIPTION
This is to attempt to clarify the difference between the `userId` and the `attributes` field and also to elevate the use-case of rolling out by an attribute rather than by a random percentage.

cc: @jordangarcia 