### PR TITLE
Update tsc to compile properly

### DIFF
--- a/packages/example-react-typescript/package.json
+++ b/packages/example-react-typescript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@optimizely/js-web-sdk": "^3.0.0-beta2",
-    "@optimizely/react-sdk": "^0.1.3-beta1",
+    "@optimizely/react-sdk": "^0.2.1-beta1",
     "node-fetch": "^2.3.0",
     "react": "^16.6.1",
     "react-dom": "^16.6.1"

--- a/packages/example-react-typescript/src/App.tsx
+++ b/packages/example-react-typescript/src/App.tsx
@@ -15,6 +15,7 @@ import {
 
 import { OptimizelySDKWrapper } from '@optimizely/js-web-sdk'
 import OTrackerButton from './TrackerButton'
+import MyHOC from './MyHOC';
 
 interface AppProps {
   optimizely: OptimizelySDKWrapper
@@ -52,6 +53,7 @@ export default class App extends React.Component<AppProps> {
         userAttributes={{ attribute1: 'yesssss' }}
       >
         <div className="App">
+          <MyHOC title="got variation: "/>
           <Example title="Decorator">
             <OTrackerButton text="jordan" />
           </Example>

--- a/packages/example-react-typescript/src/MyHOC.tsx
+++ b/packages/example-react-typescript/src/MyHOC.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { WithOptimizelyProps, UserWrappedOptimizelySDK, withOptimizely } from '@optimizely/react-sdk'
+
+interface MyProps extends WithOptimizelyProps {
+  title: string
+}
+
+const Example: React.SFC<MyProps> = ({
+  title = '',
+  optimizely,
+}: {
+  title: string
+  optimizely: UserWrappedOptimizelySDK | null
+}) => {
+  if (optimizely === null) {
+    throw new Error()
+  }
+
+  const variation = optimizely.getVariation('abtest1')
+
+  return (
+    <div className="example">
+      <h5 className="example-title">{title}: {variation}</h5>
+    </div>
+  )
+}
+
+export default withOptimizely(Example)

--- a/packages/example-react-typescript/yarn.lock
+++ b/packages/example-react-typescript/yarn.lock
@@ -36,10 +36,10 @@
     sprintf-js "^1.1.1"
     uuid "^3.3.2"
 
-"@optimizely/react-sdk@^0.1.3-beta1":
-  version "0.1.3-beta1"
-  resolved "https://registry.yarnpkg.com/@optimizely/react-sdk/-/react-sdk-0.1.3-beta1.tgz#d21476088060524022854cb06bda447ba304d864"
-  integrity sha512-OVnQ0z7VxfObpGsmgTHAQIV0pzpCdmgrJ8zadS0unf6tbEaXjA18xSlNm41PwbfBmX5KyPw7TFYV8ObfEvenlg==
+"@optimizely/react-sdk@^0.2.1-beta1":
+  version "0.2.0-beta1"
+  resolved "https://registry.yarnpkg.com/@optimizely/react-sdk/-/react-sdk-0.2.0-beta1.tgz#06395e611d6fb4d7f08a127ad1dd03cb90626157"
+  integrity sha512-SEGvGq/7C8z8vcN3Xki0ZY2rRF36HxlMVFgJn9Jw4a3wzCOwBipboDhHaCeCfSbYrzTRi9LohOle7kDauzB/dA==
   dependencies:
     prop-types "^15.6.2"
     react-broadcast "0.7.1"
@@ -5472,6 +5472,11 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.7.5:
   version "0.7.5"

--- a/packages/js-web-sdk/package.json
+++ b/packages/js-web-sdk/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-uglify": "^6.0.1",
     "sinon": "^7.2.3",
     "ts-loader": "^5.3.3",
-    "typescript": "^3.1.6",
+    "typescript": "3.5.1",
     "webpack": "^4.29.0"
   },
   "nyc": {

--- a/packages/js-web-sdk/yarn.lock
+++ b/packages/js-web-sdk/yarn.lock
@@ -4899,10 +4899,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.6:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.4.9"

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimizely/react-sdk",
-  "version": "0.2.0-beta1",
+  "version": "0.2.1-beta1",
   "description": "Use Optimizely Feature Flags and AB Tests easily in React with a library of pre-built components",
   "author": "Jordan Garcia <jordan@gmail.com>",
   "homepage": "https://github.com/optimizely/fullstack-labs/tree/master/packages/react-sdk",
@@ -34,8 +34,8 @@
     "utility-types": "^2.1.0"
   },
   "peerDependencies": {
-    "react": ">=15 || ^16",
-    "@optimizely/js-web-sdk": ">=2 || ^3"
+    "@optimizely/js-web-sdk": ">=2 || ^3",
+    "react": ">=15 || ^16"
   },
   "devDependencies": {
     "@optimizely/js-web-sdk": "3.0.0-beta1",
@@ -57,6 +57,7 @@
     "rollup-plugin-typescript2": "^0.18.1",
     "rollup-plugin-uglify": "^6.0.1",
     "ts-jest": "^23.10.5",
+    "typescript": "3.5.1",
     "tslib": "^1.9.3"
   }
 }

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { UserWrappedOptimizelySDK } from './createUserWrapper'
 export { OptimizelyProvider } from './Provider';
 export { OptimizelyFeature } from './Feature'
 export { withOptimizely, WithOptimizelyProps } from './withOptimizely'

--- a/packages/react-sdk/src/withOptimizely.tsx
+++ b/packages/react-sdk/src/withOptimizely.tsx
@@ -17,7 +17,7 @@ import * as React from 'react'
 import { Subtract } from 'utility-types'
 
 import { OptimizelyContextConsumer } from './Context'
-import { UserWrappedOptimizelySDK } from './createUserWrapper';
+import { UserWrappedOptimizelySDK } from './createUserWrapper'
 
 export interface WithOptimizelyProps {
   optimizely: UserWrappedOptimizelySDK | null
@@ -27,7 +27,7 @@ export interface WithOptimizelyProps {
 
 export function withOptimizely<P extends WithOptimizelyProps>(
   Component: React.ComponentType<P>,
-) {
+): React.ComponentType<Subtract<P, WithOptimizelyProps>> {
   return class WithOptimizely extends React.Component<Subtract<P, WithOptimizelyProps>> {
     render() {
       return (
@@ -37,6 +37,7 @@ export function withOptimizely<P extends WithOptimizelyProps>(
             isServerSide: boolean
             timeout: number | undefined
           }) => (
+            // @ts-ignore
             <Component
               {...this.props}
               optimizely={value.optimizely}

--- a/packages/react-sdk/yarn.lock
+++ b/packages/react-sdk/yarn.lock
@@ -4032,6 +4032,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typescript@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+
 uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"


### PR DESCRIPTION
This fixes the problem where the `react-sdk` would compile or not compile depending on what version of typescript is installed globally.  This installs `typescript` as a `devDependency`

