### PR TITLE
refactor(react-sdk/js-web-sdk): fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository is a monorepo that we manage using [Lerna](https://github.com/le
 
 | Package | Status | Version | Description |
 | --- | --- | --- | --- |
-| [`js-web-sdk`](./packages/js-web-sdk) | beta | `3.0.0-beta3` | Browser wrapper for Optimizely's Javascript SDK. |
-| [`react-sdk`](./packages/react-sdk) | beta |  `0.2.0-beta3` |Use Optimizely Feature Flags and AB Tests easily in React with a library of pre-built components.|
+| [`js-web-sdk`](./packages/js-web-sdk) | beta | `3.0.1-beta1` | Browser wrapper for Optimizely's Javascript SDK. |
+| [`react-sdk`](./packages/react-sdk) | beta |  `0.3.0-beta1` |Use Optimizely Feature Flags and AB Tests easily in React with a library of pre-built components.|
 | [`example-react-16`](./packages/example-react-16) | example | `--` | A simple example using `js-web-sdk` and `react-sdk` in React 16 |
 | [`example-react-typescript`](./packages/example-react-typescript) | example | `--` | A simple example using `js-web-sdk` and `react-sdk` in React + TypeScript |
 | [`example-react-15`](./packages/example-react-15) | example | `--` | A simple example using `js-web-sdk` and `react-sdk` in React 15 |

--- a/packages/js-web-sdk/README.md
+++ b/packages/js-web-sdk/README.md
@@ -68,7 +68,7 @@ initApp()
 
 #### `optimizely.onReady()` to block rendering
 
-By using `await optimizely.onReady()` you can gaurantee code wont be run until the datafile is downloaded
+By using `await optimizely.onReady()` you can guarantee code wont be run until the datafile is downloaded
 
 ```js
 import * as optimizelySDK from '@optimizely/js-web-sdk'
@@ -77,11 +77,11 @@ const optimizely = optimizelySDK.createInstance({
 })
 
 await optimizely.onReady()
-// at this point datafile is gauranteed to be loaded
+// at this point datafile is guaranteed to be loaded
 initApp()
 ```
 
-However, the above example isn't great because Optimizely could time out due to network connectivity issues.  By passing a `timeout` to `optimizely.onReady()` we can gaurantee that Optimizely won't block the page for more than X milliseconds.
+However, the above example isn't great because Optimizely could time out due to network connectivity issues.  By passing a `timeout` to `optimizely.onReady()` we can guarantee that Optimizely won't block the page for more than X milliseconds.
 
 ```js
 import * as optimizelySDK from '@optimizely/js-web-sdk'

--- a/packages/react-sdk/src/Experiment.spec.tsx
+++ b/packages/react-sdk/src/Experiment.spec.tsx
@@ -78,7 +78,7 @@ describe('<OptimizelyExperiment>', () => {
       expect(optimizelyMock.onReady).toHaveBeenCalledWith({ timeout: 100 })
       // while it's waiting for onReady()
       expect(component.text()).toBe('')
-      resolver.resolve({ sucess: true })
+      resolver.resolve({ success: true })
 
       await optimizelyMock.onReady()
 
@@ -100,7 +100,7 @@ describe('<OptimizelyExperiment>', () => {
       expect(optimizelyMock.onReady).toHaveBeenCalledWith({ timeout: 200 })
       // while it's waiting for onReady()
       expect(component.text()).toBe('')
-      resolver.resolve({ sucess: true })
+      resolver.resolve({ success: true })
 
       await optimizelyMock.onReady()
 
@@ -198,7 +198,7 @@ describe('<OptimizelyExperiment>', () => {
       expect(component.text()).toBe('')
     })
 
-    describe('when the onReady() promise return { sucess: false }', () => {
+    describe('when the onReady() promise return { success: false }', () => {
       it('should still render', async () => {
         const component = mount(
           <OptimizelyProvider optimizely={optimizelyMock}>

--- a/packages/react-sdk/src/Feature.spec.tsx
+++ b/packages/react-sdk/src/Feature.spec.tsx
@@ -107,7 +107,7 @@ describe('<OptimizelyFeature>', () => {
 
       // while it's waiting for onReady()
       expect(component.text()).toBe('')
-      resolver.resolve({ sucess: true })
+      resolver.resolve({ success: true })
 
       await optimizelyMock.onReady()
 
@@ -133,7 +133,7 @@ describe('<OptimizelyFeature>', () => {
 
       // while it's waiting for onReady()
       expect(component.text()).toBe('')
-      resolver.resolve({ sucess: true })
+      resolver.resolve({ success: true })
 
       await optimizelyMock.onReady()
 
@@ -160,7 +160,7 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('')
-        resolver.resolve({ sucess: true })
+        resolver.resolve({ success: true })
 
         await optimizelyMock.onReady()
 
@@ -209,7 +209,7 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('')
-        resolver.resolve({ sucess: true })
+        resolver.resolve({ success: true })
 
         await optimizelyMock.onReady()
 
@@ -258,7 +258,7 @@ describe('<OptimizelyFeature>', () => {
 
         // while it's waiting for onReady()
         expect(component.text()).toBe('')
-        resolver.resolve({ sucess: false, reason: 'fail' })
+        resolver.resolve({ success: false, reason: 'fail' })
 
         await optimizelyMock.onReady()
 

--- a/packages/react-sdk/src/client.ts
+++ b/packages/react-sdk/src/client.ts
@@ -125,7 +125,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     id: null,
     attributes: {},
   }
-  private userPromiseResovler: (user: UserContext) => void
+  private userPromiseResolver: (user: UserContext) => void
   private userPromise: Promise<OnReadyResult>
   private isUserPromiseResolved: boolean = false
   private onUserUpdateHandlers: OnUserUpdateHandler[] = []
@@ -142,11 +142,11 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
   constructor(config: optimizely.Config) {
     this.initialConfig = config
 
-    this.userPromiseResovler = () => {}
+    this.userPromiseResolver = () => {}
     this._client = optimizely.createInstance(config)
 
     this.userPromise = new Promise(resolve => {
-      this.userPromiseResovler = resolve
+      this.userPromiseResolver = resolve
     }).then(() => ({ success: true }))
 
     this.dataReadyPromise = Promise.all([this.userPromise, this._client.onReady()]).then(
@@ -191,7 +191,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
       this.user.attributes = userInfo.attributes
     }
     if (!this.isUserPromiseResolved) {
-      this.userPromiseResovler(this.user)
+      this.userPromiseResolver(this.user)
       this.isUserPromiseResolved = true
     }
     this.onUserUpdateHandlers.forEach(handler => handler(this.user))


### PR DESCRIPTION
This PR corrects the following typos:
- "gaurantee" -> "guarantee"
- "sucess" -> "success"
- "userPromiseResovler" -> "userPromiseResolver"

It also updates the README to correctly list the latest version of the React SDK and JS Web SDK packages.