### PR TITLE
feat (React SDK): Add disabled event dispatcher

### DIFF
--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Added disabledEventDispatcher, which can be used to disable sending all events to Optimizely's results backend
+
 ## 0.3.0-beta1
 * Remove js-web-sdk dependency, add optimizely-sdk dependency.
 * Refactor to use ReactSDKClient as the interface between the core Optimizely SDK and the React SDK

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Added disabledEventDispatcher, which can be used to disable sending all events to Optimizely's results backend
+* Added logOnlyEventDispatcher, which can be used to disable sending all events to Optimizely's results backend
 
 ## 0.3.0-beta1
 * Remove js-web-sdk dependency, add optimizely-sdk dependency.

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -228,8 +228,8 @@ To rollout or experiment on a feature by user rather than by random percentage, 
   <OptimizelyProvider
     optimizely={optimizely}
     timeout={500}
-    userId={'user123'}     // UserId used for random percentage rollout 
-    userAttributes={{ 
+    userId={'user123'}     // UserId used for random percentage rollout
+    userAttributes={{
       user_id: 'user123'   // Attribute used for non-random audience rollout
       plan_type: 'bronze',
     }}
@@ -357,6 +357,17 @@ async function main() {
   console.log('output', output)
 }
 main()
+```
+
+## Disabled event dispatcher
+To disable sending all events to Optimizely's results backend, use the `disabledEventDispatcher` when creating a client:
+```js
+import { createInstance, disabledEventDispatcher } from '@optimizely/react-sdk'
+
+const optimizely = createInstance({
+  datafile: window.datafile,
+  eventDispatcher: disabledEventDispatcher,
+})
 ```
 
 ## Credits

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -360,13 +360,13 @@ main()
 ```
 
 ## Disabled event dispatcher
-To disable sending all events to Optimizely's results backend, use the `disabledEventDispatcher` when creating a client:
+To disable sending all events to Optimizely's results backend, use the `logOnlyEventDispatcher` when creating a client:
 ```js
-import { createInstance, disabledEventDispatcher } from '@optimizely/react-sdk'
+import { createInstance, logOnlyEventDispatcher } from '@optimizely/react-sdk'
 
 const optimizely = createInstance({
   datafile: window.datafile,
-  eventDispatcher: disabledEventDispatcher,
+  eventDispatcher: logOnlyEventDispatcher,
 })
 ```
 

--- a/packages/react-sdk/src/disabledEventDispatcher.ts
+++ b/packages/react-sdk/src/disabledEventDispatcher.ts
@@ -20,11 +20,11 @@ import * as logging from '@optimizely/js-sdk-logging'
 const logger = logging.getLogger('ReactSDK')
 
 /**
- * disabledEventDispatcher only logs a message at the debug level, and does not
+ * logOnlyEventDispatcher only logs a message at the debug level, and does not
  * send any requests to the Optimizely results backend. Use this to disable
  * all event dispatching.
  */
-const disabledEventDispatcher: optimizely.EventDispatcher = {
+const logOnlyEventDispatcher: optimizely.EventDispatcher = {
   dispatchEvent(event: optimizely.Event, callback: () => void): void {
     logger.debug('Event not dispatched by disabled event dispatcher: %s', () => {
       let eventStr: string
@@ -38,4 +38,4 @@ const disabledEventDispatcher: optimizely.EventDispatcher = {
   }
 }
 
-export default disabledEventDispatcher
+export default logOnlyEventDispatcher

--- a/packages/react-sdk/src/disabledEventDispatcher.ts
+++ b/packages/react-sdk/src/disabledEventDispatcher.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as optimizely from '@optimizely/optimizely-sdk'
+import * as logging from '@optimizely/js-sdk-logging'
+
+const logger = logging.getLogger('ReactSDK')
+
+/**
+ * disabledEventDispatcher only logs a message at the debug level, and does not
+ * send any requests to the Optimizely results backend. Use this to disable
+ * all event dispatching.
+ */
+const disabledEventDispatcher: optimizely.EventDispatcher = {
+  dispatchEvent(event: optimizely.Event, callback: () => void): void {
+    logger.debug('Event not dispatched by disabled event dispatcher: %s', () => {
+      let eventStr: string
+      try {
+        eventStr = JSON.stringify(event)
+      } catch (err) {
+        eventStr = 'error stringifying event'
+      }
+      return eventStr
+    })
+  }
+}
+
+export default disabledEventDispatcher

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -29,3 +29,5 @@ export {
 } from '@optimizely/optimizely-sdk'
 
 export { createInstance, ReactSDKClient } from './client'
+
+export { default as disabledEventDispatcher } from './disabledEventDispatcher'

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -30,4 +30,4 @@ export {
 
 export { createInstance, ReactSDKClient } from './client'
 
-export { default as disabledEventDispatcher } from './disabledEventDispatcher'
+export { default as logOnlyEventDispatcher } from './logOnlyEventDispatcher'


### PR DESCRIPTION
Add `disabledEventDispatcher`, an event dispatcher that only logs a message at the debug level, and does not send any request to the Optimizely results backend.