### PR TITLE
(React SDK) Update docs (migration, readme, changelog) to reflect new React version requirements

### DIFF
--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 * Added logOnlyEventDispatcher, which can be used to disable sending all events to Optimizely's results backend
+* Added support for ref forwarding and copying of non-React statics in withOptimizely HOC
 
 ## 0.3.0-beta1
 * Remove js-web-sdk dependency, add optimizely-sdk dependency.

--- a/packages/react-sdk/MIGRATION.md
+++ b/packages/react-sdk/MIGRATION.md
@@ -131,6 +131,8 @@ class App extends React.Component {
 
 ReactDOM.render(<App />, document.getElementById('root'))
 ```
+#### Ref Forwarding in withOptimizely, and new minimum React version
+The `withOptimizely` HOC now supports [ref forwarding](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-in-higher-order-components). As a result, we have ***dropped support for React version <16.3***, which was the version that introduced the ref forwarding API.
 #### Logging support
 You can now configure a logger and log level directly via the React SDK:
 ```js

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -12,12 +12,11 @@ Optimizely Rollouts is free feature flags for development teams. Easily roll out
 - User ID + attributes memoization
 - Render blocking until datafile is ready via a React API
 - Optimizely timeout (only block rendering up to the number of milliseconds you specify)
-- Event queuing for `track`, which allows `track` calls to happen before datafile is downloaded
 - Library of React components to use with [feature flags](https://docs.developers.optimizely.com/full-stack/docs/use-feature-flags) and [A/B tests](https://docs.developers.optimizely.com/full-stack/docs/run-a-b-tests)
 
 ### Compatibility
 
-`React 15.x +`
+The React SDK is compatible with `React 16.3.0 +`
 
 ### Example
 


### PR DESCRIPTION
With the introduction of ref forwarding in withOptimizely in #32, React SDK is no longer compatible with React versions prior to the introduction of `React.forwardRef`, which came in [16.3.0](https://github.com/facebook/react/blob/master/CHANGELOG.md#1630-march-29-2018).

This PR updates relevant documentation files to reflect the new minimum version.