### PR TITLE
(React SDK) Add clientEngine: react-sdk when creating the inner SDK instance

### DIFF
--- a/packages/react-sdk/src/client.spec.ts
+++ b/packages/react-sdk/src/client.spec.ts
@@ -75,9 +75,17 @@ describe('ReactSDKClient', () => {
   it('provides access to the underlying client', () => {
     const instance = createInstance(config)
     expect(createInstanceSpy).toBeCalledTimes(1)
-    expect(createInstanceSpy).toBeCalledWith(config)
     expect(createInstanceSpy.mock.results[0].isThrow).toBe(false)
     expect(createInstanceSpy.mock.results[0].value).toBe(instance.client)
+  })
+
+  it('adds clientEngine react-sdk the config, and passed the config to createInstance', () => {
+    createInstance(config)
+    expect(createInstanceSpy).toBeCalledTimes(1)
+    expect(createInstanceSpy).toBeCalledWith({
+      ...config,
+      clientEngine: 'react-sdk',
+    })
   })
 
   it('provides access to the underlying client notificationCenter', () => {

--- a/packages/react-sdk/src/client.ts
+++ b/packages/react-sdk/src/client.ts
@@ -143,7 +143,12 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
     this.initialConfig = config
 
     this.userPromiseResovler = () => {}
-    this._client = optimizely.createInstance(config)
+
+    const configWithClientEngine = {
+      ...config,
+      clientEngine: 'react-sdk',
+    }
+    this._client = optimizely.createInstance(configWithClientEngine)
 
     this.userPromise = new Promise(resolve => {
       this.userPromiseResovler = resolve

--- a/packages/react-sdk/src/client.ts
+++ b/packages/react-sdk/src/client.ts
@@ -32,6 +32,8 @@ export type OnReadyResult = {
   reason?: string
 }
 
+const REACT_SDK_CLIENT_ENGINE = 'react-sdk'
+
 export interface ReactSDKClient extends optimizely.Client {
   user: UserContext
 
@@ -146,7 +148,7 @@ class OptimizelyReactSDKClient implements ReactSDKClient {
 
     const configWithClientEngine = {
       ...config,
-      clientEngine: 'react-sdk',
+      clientEngine: REACT_SDK_CLIENT_ENGINE,
     }
     this._client = optimizely.createInstance(configWithClientEngine)
 


### PR DESCRIPTION
With this change, events are sent with the correct identifier for React SDK