### PR TITLE
chore(React SDK): Update React peerDependency version range

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -37,7 +37,7 @@
     "utility-types": "^2.1.0"
   },
   "peerDependencies": {
-    "react": ">=15 || ^16"
+    "react": ">=16.3.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.15",


### PR DESCRIPTION
In https://github.com/optimizely/fullstack-labs/pull/35 we updated the React minimum compatible version to 16.3.0. This change updates peerDependencies in package.json to reflect this requirement.