### PR TITLE
chore (ReactSDK Exports): Export the context provider/consumer pair to assist with unit testing

### DIFF
--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { OptimizelyContextConsumer, OptimizelyContextProvider } from './Context'
 export { OptimizelyProvider } from './Provider'
 export { OptimizelyFeature } from './Feature'
 export { withOptimizely, WithOptimizelyProps, WithoutOptimizelyProps } from './withOptimizely'


### PR DESCRIPTION
## Summary

In order to make unit test of components which use any of the conditional render component wrappers, export the global context instance used by `<OptimizelyProvider />` so that testers can provide it to Enzyme's mount:

```js
import { OptimizelyContextProvider } from '@optimizely/react-sdk';
...
mount(<MyComponent />, { context: { OptimizelyContextProvider } } )
```